### PR TITLE
Improve `AppendRequestIdProcessor `

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,11 @@
 .buildpath
 .settings/
 .project
+.bashrc
 *.patch
 .idea/
+.vscode/
+.fleet/
 .git/
 runtime/
 vendor/

--- a/app/Kernel/Log/AppendRequestIdProcessor.php
+++ b/app/Kernel/Log/AppendRequestIdProcessor.php
@@ -22,8 +22,17 @@ class AppendRequestIdProcessor implements ProcessorInterface
 
     public function __invoke(array|LogRecord $record)
     {
-        $record['extra']['request_id'] = Context::getOrSet(self::REQUEST_ID, uniqid());
-        $record['extra']['coroutine_id'] = Coroutine::id();
+        $context = array_replace($record['context'] ?? [], [
+            'request_id' => Context::getOrSet(self::REQUEST_ID, uniqid()),
+            'coroutine_id' => Coroutine::id(),
+        ]);
+
+        if (is_array($record)) {
+            $record['context'] = $context;
+        } else {
+            $record = $record->with(context: $context);
+        }
+
         return $record;
     }
 }


### PR DESCRIPTION
`Monolog\LogRecord::offsetSet()` in `v3.0+`

```php
    public function offsetSet(mixed $offset, mixed $value): void
    {
        if ($offset === 'extra') {
            if (!is_array($value)) {
                throw new \InvalidArgumentException('extra must be an array');
            }

            $this->extra = $value;

            return;
        }

        if ($offset === 'formatted') {
            $this->formatted = $value;

            return;
        }

        throw new \LogicException('Unsupported operation: setting '.$offset);
    }
```